### PR TITLE
Update api folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 # WIP
 
-This repo does two things:
-
-1. Provides a set of transform functions to be used when migrating a Strapi application from v3 to v4.  These are found in the `transforms` directory
-2. Provides a script, `migrate-plugin.js` , that takes a Strapi plugin and attempts to migrate the plugin by moving files and applying codemods where needed.
+This repo uses jscodeshift and node scripts to migrate a Strapi v3 application or plugin to v4
 
 ## Migration helpers
 
@@ -19,9 +16,9 @@ node <path/to/strapi-codemods/migration-helpers/update-api-folder-structure>
 
 ## Transforms
 
-You can install `jscodeshift` globally or use npx.  See jscodeshift docs for all available options: [https://github.com/facebook/jscodeshift](https://github.com/facebook/jscodeshift)
+You can install `jscodeshift` globally or use npx. See jscodeshift docs for all available options: [https://github.com/facebook/jscodeshift](https://github.com/facebook/jscodeshift)
 
-To use this repository for migrating a strapi application, I recommend cloning the repo into the application you want to migrate. 
+To use this repository for migrating a strapi application, I recommend cloning the repo into the application you want to migrate.
 
 The commands provided below will make changes to your source code
 
@@ -29,7 +26,7 @@ I recommend initialize a git repository if you don't already have one and add `s
 
 Make sure your git tree is clean before running any commands, and the git diff after to see what changed.
 
-*There is a dry run option from jscodeshift but it doesn't show you what was changed*
+_There is a dry run option from jscodeshift but it doesn't show you what was changed_
 
 Example jscodehsift command:
 
@@ -37,7 +34,7 @@ Example jscodehsift command:
 npx jscodeshift -t <path-to-transform> <path-to-file(s)>
 ```
 
-*You can pass multiple files or a directory*
+_You can pass multiple files or a directory_
 
 ### change-find-to-findMany
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ This repo does two things:
 1. Provides a set of transform functions to be used when migrating a Strapi application from v3 to v4.  These are found in the `transforms` directory
 2. Provides a script, `migrate-plugin.js` , that takes a Strapi plugin and attempts to migrate the plugin by moving files and applying codemods where needed.
 
+## Migration helpers
+
+### update-api-folder-structure
+
+Navigate to the strapi project you want to migrate
+
+```bash
+node <path/to/strapi-codemods/migration-helpers/update-api-folder-structure>
+```
+
 ## Transforms
 
 You can install `jscodeshift` globally or use npx.  See jscodeshift docs for all available options: [https://github.com/facebook/jscodeshift](https://github.com/facebook/jscodeshift)

--- a/migration-helpers/update-api-folder-structure.js
+++ b/migration-helpers/update-api-folder-structure.js
@@ -172,14 +172,6 @@ const updatePolicies = async (apiPath) => {
 };
 
 /**
- * @description Runs a jscodeshift transform
- * @param {string} servicesDir Path to the services folder for the current api
- */
-const updateServices = (servicesDirPath) => {
-  runJsCodeshift(servicesDirPath, "use-arrow-function-for-service-export");
-};
-
-/**
  *
  * @description Recursively cleans a directory
  *
@@ -241,10 +233,11 @@ const updateApiFolderStructure = async () => {
     await updateContentTypes(apiPath);
     await updateRoutes(apiPath, apiName);
     await updatePolicies(apiPath);
-    updateServices(join(apiPath, "services"));
+    // Update services using jscodeshift transform
+    runJsCodeshift(join(apiDirCopyPath, "services"), "use-arrow-function-for-service-export");
   }
 
-  console.log(`migrated ${basename(strapiAppPath)}/api`);
+  console.log(`migrated ${basename(strapiAppPath)}/api to Strapi v4`);
   console.log(`to see changes: Run "git add . && git diff --cached"`);
   console.log('to revert: "git reset HEAD --hard && git clean -fd"');
   console.log('to accept: "git commit -am "migrate API to v4 structure""');

--- a/migration-helpers/update-api-folder-structure.js
+++ b/migration-helpers/update-api-folder-structure.js
@@ -5,7 +5,7 @@
 const { resolve, join, basename } = require("path");
 const fs = require("fs-extra");
 const _ = require("lodash");
-var pluralize = require("pluralize");
+_.mixin(require("lodash-inflection"));
 const { inspect } = require("util");
 const runJsCodeshift = require("../utils/runJsCodeshift");
 
@@ -43,7 +43,7 @@ const convertModelToContentType = async (apiPath, contentTypeName) => {
     const schemaJson = { ...settingsJson };
     const infoUpdate = {
       singularName: contentTypeName,
-      pluralName: pluralize(contentTypeName),
+      pluralName: _.pluralize(contentTypeName),
       displayName: contentTypeName,
       name: contentTypeName,
     };

--- a/migration-helpers/update-api-folder-structure.js
+++ b/migration-helpers/update-api-folder-structure.js
@@ -113,7 +113,7 @@ const updateRoutes = async (apiPath, apiName) => {
         !route.handler.includes("count") || !route.path.includes("count")
     );
 
-    // Recursively transform objects to strings
+    // Transform objects to strings
     const routesToString = inspect(
       { routes: updatedRoutes },
       { depth: Infinity }
@@ -198,7 +198,6 @@ const clean = async (dirs, baseDir) => {
       } else {
         // Otherwise get the directories of the current directory
         const currentDirs = await getDirsAtPath(currentDirPath);
-        // Recursively clean the directories
         await clean(currentDirs, currentDirPath);
       }
     } catch (error) {
@@ -210,7 +209,7 @@ const clean = async (dirs, baseDir) => {
 /**
  * @description Get's directory entries from a given path
  *
- * @param {*} path The path to the directory
+ * @param {string} path The path to the directory
  * @returns array of of directory entries
  */
 const getDirsAtPath = async (path) => {
@@ -230,7 +229,6 @@ const renameApiFolder = async (apiDirCopyPath, strapiAppPath) => {
 };
 
 const updateApiFolderStructure = async () => {
-  // Make a copy of the api folder => api-copy
   const strapiAppPath = resolve(process.cwd());
   const apiDirCopyPath = join(strapiAppPath, "api-copy");
   await fs.copy(join(strapiAppPath, "api"), apiDirCopyPath);

--- a/migration-helpers/update-api-folder-structure.js
+++ b/migration-helpers/update-api-folder-structure.js
@@ -1,0 +1,136 @@
+/**
+ * Migrate API folder structure to v4
+ */
+
+const { resolve, join } = require("path");
+const fs = require("fs-extra");
+const _ = require("lodash");
+var pluralize = require("pluralize");
+const j = require("jscodeshift");
+const { inspect } = require("util");
+
+const normalizeName = _.kebabCase;
+
+const updateContentTypes = async (apiDirCopyPath, apiName) => {
+  try {
+    const schemaSettingsJson = join(
+      apiDirCopyPath,
+      apiName,
+      "models",
+      `${apiName}.settings.json`
+    );
+    const exists = await fs.exists(schemaSettingsJson);
+    if (!exists) {
+      console.error(`${apiName}.settings.json does not exist`);
+    }
+
+    // Read the settings.json file
+    const settingsJson = await fs.readJson(schemaSettingsJson);
+    // Create a copy
+    const schemaJson = { ...settingsJson };
+    const infoUpdate = {
+      singularName: apiName,
+      pluralName: pluralize(apiName),
+      displayName: apiName,
+      name: apiName,
+    };
+    // Modify the JSON
+    _.set(schemaJson, "info", infoUpdate);
+    // Create the new content-types/api/schema.json file
+    await fs.ensureFile(
+      join(apiDirCopyPath, apiName, "content-types", apiName, "schema.json")
+    );
+    // Write modified JSON to schema.json
+    await fs.writeJSON(
+      join(apiDirCopyPath, apiName, "content-types", apiName, "schema.json"),
+      schemaJson,
+      {
+        spaces: 2,
+      }
+    );
+
+    // Delete the models folder
+    await fs.remove(join(apiDirCopyPath, apiName, "models"));
+  } catch (error) {
+    console.error(error.message);
+  }
+};
+
+const updateRoutes = async (apiDirCopyPath, apiName) => {
+  try {
+    // Create the js file
+    await fs.ensureFile(
+      join(apiDirCopyPath, apiName, "routes", `${apiName}.js`)
+    );
+
+    // Create write stream for new js file
+    const file = fs.createWriteStream(
+      join(apiDirCopyPath, apiName, "routes", `${apiName}.js`)
+    );
+    // Get the existing JSON routes file
+    const routesJson = await fs.readJson(
+      join(apiDirCopyPath, apiName, "config", "routes.json")
+    );
+    // Recursively transform objects to strings
+    const routes = inspect(routesJson, { depth: Infinity });
+
+    // Export routes from create js file
+    file.write(`module.exports = ${routes}`);
+
+    // Close the write stream
+    file.end();
+
+    // Delete config/routes.json
+    await fs.remove(join(apiDirCopyPath, apiName, "config", "routes.json"));
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const updatePolicies = async (apiDirCopyPath, apiName) => {
+  const v3PoliciesPath = join(apiDirCopyPath, apiName, "config", "policies");
+  const exists = await fs.exists(v3PoliciesPath);
+  if (!exists) return;
+
+  const v3Policies = await fs.readdir(v3PoliciesPath, { withFileTypes: true });
+  const policyFiles = v3Policies.filter((fd) => fd.isFile());
+
+  for (const policy of policyFiles) {
+    try {
+      await fs.copy(
+        v3PoliciesPath,
+        join(apiDirCopyPath, apiName, "policies", policy.name)
+      );
+
+      await fs.remove(join(v3PoliciesPath, policy.name));
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+};
+
+const clean = () => {
+  console.log("just gotta check for empty dirs");
+};
+
+const updateApiFolderStructure = async () => {
+  // Make a copy of the api folder => api-copy
+  const strapiAppPath = resolve(process.cwd());
+  const apiDirCopyPath = join(strapiAppPath, "api-copy");
+  await fs.copy(join(strapiAppPath, "api"), apiDirCopyPath);
+
+  // Get the apis
+  const apis = await fs.readdir(apiDirCopyPath, { withFileTypes: true });
+  const apiDirs = apis.filter((fd) => fd.isDirectory());
+
+  for (const api of apiDirs) {
+    const apiName = normalizeName(api.name);
+    await updateContentTypes(apiDirCopyPath, apiName);
+    await updateRoutes(apiDirCopyPath, apiName);
+    await updatePolicies(apiDirCopyPath, apiName);
+  }
+
+  clean();
+};
+
+updateApiFolderStructure();

--- a/migration-helpers/update-api-folder-structure.js
+++ b/migration-helpers/update-api-folder-structure.js
@@ -6,111 +6,153 @@ const { resolve, join } = require("path");
 const fs = require("fs-extra");
 const _ = require("lodash");
 var pluralize = require("pluralize");
-const j = require("jscodeshift");
 const { inspect } = require("util");
 
 const normalizeName = _.kebabCase;
 
-const updateContentTypes = async (apiDirCopyPath, apiName) => {
+const convertModelToContentType = async (apiPath, contentTypeName) => {
+  const settingsJsonPath = join(
+    apiPath,
+    "models",
+    `${contentTypeName}.settings.json`
+  );
+  const exists = await fs.exists(settingsJsonPath);
+  if (!exists) {
+    console.error(`${contentTypeName}.settings.json does not exist`);
+  }
+
+  // Read the settings.json file
+  const settingsJson = await fs.readJson(settingsJsonPath);
+  // Create a copy
+  const schemaJson = { ...settingsJson };
+  const infoUpdate = {
+    singularName: contentTypeName,
+    pluralName: pluralize(contentTypeName),
+    displayName: contentTypeName,
+    name: contentTypeName,
+  };
+  // Modify the JSON
+  _.set(schemaJson, "info", infoUpdate);
+  // Create the new content-types/api/schema.json file
+  await fs.ensureFile(
+    join(apiPath, "content-types", contentTypeName, "schema.json")
+  );
+  // Write modified JSON to schema.json
+  await fs.writeJSON(
+    join(apiPath, "content-types", contentTypeName, "schema.json"),
+    schemaJson,
+    {
+      spaces: 2,
+    }
+  );
+};
+
+const updateContentTypes = async (apiPath) => {
   try {
-    const schemaSettingsJson = join(
-      apiDirCopyPath,
-      apiName,
-      "models",
-      `${apiName}.settings.json`
+    const allModels = await fs.readdir(join(apiPath, "models"), {
+      withFileTypes: true,
+    });
+    const allModelFiles = allModels.filter(
+      (f) => f.isFile() && f.name.includes("settings")
     );
-    const exists = await fs.exists(schemaSettingsJson);
-    if (!exists) {
-      console.error(`${apiName}.settings.json does not exist`);
+
+    if (allModelFiles.length > 1) {
+      // loop
+      for (const model of allModelFiles) {
+        const [contentTypeName] = model.name.split(".");
+        await convertModelToContentType(apiPath, contentTypeName);
+      }
+    } else {
+      // skip the loop
+      const [contentTypeName] = allModelFiles[0].name.split(".");
+      await convertModelToContentType(apiPath, contentTypeName);
     }
 
-    // Read the settings.json file
-    const settingsJson = await fs.readJson(schemaSettingsJson);
-    // Create a copy
-    const schemaJson = { ...settingsJson };
-    const infoUpdate = {
-      singularName: apiName,
-      pluralName: pluralize(apiName),
-      displayName: apiName,
-      name: apiName,
-    };
-    // Modify the JSON
-    _.set(schemaJson, "info", infoUpdate);
-    // Create the new content-types/api/schema.json file
-    await fs.ensureFile(
-      join(apiDirCopyPath, apiName, "content-types", apiName, "schema.json")
-    );
-    // Write modified JSON to schema.json
-    await fs.writeJSON(
-      join(apiDirCopyPath, apiName, "content-types", apiName, "schema.json"),
-      schemaJson,
-      {
-        spaces: 2,
-      }
-    );
-
-    // Delete the models folder
-    await fs.remove(join(apiDirCopyPath, apiName, "models"));
+    // Delete the v3 models folder
+    await fs.remove(join(apiPath, "models"));
   } catch (error) {
     console.error(error.message);
   }
 };
 
-const updateRoutes = async (apiDirCopyPath, apiName) => {
+const updateRoutes = async (apiPath, apiName) => {
   try {
     // Create the js file
-    await fs.ensureFile(
-      join(apiDirCopyPath, apiName, "routes", `${apiName}.js`)
-    );
+    await fs.ensureFile(join(apiPath, "routes", `${apiName}.js`));
 
     // Create write stream for new js file
-    const file = fs.createWriteStream(
-      join(apiDirCopyPath, apiName, "routes", `${apiName}.js`)
-    );
+    const file = fs.createWriteStream(join(apiPath, "routes", `${apiName}.js`));
     // Get the existing JSON routes file
     const routesJson = await fs.readJson(
-      join(apiDirCopyPath, apiName, "config", "routes.json")
+      join(apiPath, "config", "routes.json")
     );
+    const { routes } = routesJson;
+
+    // Remove count
+    const updatedRoutes = routes.filter(
+      (route) => !route.handler.includes("count")
+    );
+
     // Recursively transform objects to strings
-    const routes = inspect(routesJson, { depth: Infinity });
+    const routesToString = inspect(
+      { routes: updatedRoutes },
+      { depth: Infinity }
+    );
 
     // Export routes from create js file
-    file.write(`module.exports = ${routes}`);
+    file.write(`module.exports = ${routesToString}`);
 
     // Close the write stream
     file.end();
 
-    // Delete config/routes.json
-    await fs.remove(join(apiDirCopyPath, apiName, "config", "routes.json"));
+    // Delete the v3 config/routes.json
+    await fs.remove(join(apiPath, "config", "routes.json"));
   } catch (error) {
     console.error(error);
   }
 };
 
-const updatePolicies = async (apiDirCopyPath, apiName) => {
-  const v3PoliciesPath = join(apiDirCopyPath, apiName, "config", "policies");
+const updatePolicies = async (apiPath) => {
+  const v3PoliciesPath = join(apiPath, "config", "policies");
   const exists = await fs.exists(v3PoliciesPath);
   if (!exists) return;
 
   const v3Policies = await fs.readdir(v3PoliciesPath, { withFileTypes: true });
   const policyFiles = v3Policies.filter((fd) => fd.isFile());
 
-  for (const policy of policyFiles) {
-    try {
-      await fs.copy(
-        v3PoliciesPath,
-        join(apiDirCopyPath, apiName, "policies", policy.name)
-      );
+  // The old policy folder is empty, delete it
+  if (!policyFiles.length) {
+    await fs.remove(v3PoliciesPath);
+  }
 
-      await fs.remove(join(v3PoliciesPath, policy.name));
-    } catch (error) {
-      console.error(error.message);
+  const v4PoliciesPath = join(apiPath, "policies");
+  if (policyFiles.length > 1) {
+    for (const policy of policyFiles) {
+      try {
+        await fs.copy(v3PoliciesPath, join(v4PoliciesPath, policy.name));
+        // Remove the current v3 policy
+        await fs.remove(join(v3PoliciesPath, policy.name));
+      } catch (error) {
+        console.error(error.message);
+      }
     }
+  } else {
+    await fs.copy(v3PoliciesPath, join(v4PoliciesPath, policyFiles[0].name));
+    // The last policy has been copied, delete the v3 policy folder
+    await fs.remove(v3PoliciesPath);
   }
 };
 
-const clean = () => {
-  console.log("just gotta check for empty dirs");
+const clean = async () => {
+  console.log("done");
+};
+
+const renameApiFolder = async (apiDirCopyPath) => {
+  try {
+    await fs.rename(apiDirCopyPath, "api");
+  } catch (error) {
+    console.error(error.message);
+  }
 };
 
 const updateApiFolderStructure = async () => {
@@ -125,12 +167,14 @@ const updateApiFolderStructure = async () => {
 
   for (const api of apiDirs) {
     const apiName = normalizeName(api.name);
-    await updateContentTypes(apiDirCopyPath, apiName);
-    await updateRoutes(apiDirCopyPath, apiName);
-    await updatePolicies(apiDirCopyPath, apiName);
+    const apiPath = join(apiDirCopyPath, apiName);
+    await updateContentTypes(apiPath);
+    await updateRoutes(apiPath, apiName);
+    await updatePolicies(apiPath);
   }
 
   clean();
+  await renameApiFolder(apiDirCopyPath);
 };
 
 updateApiFolderStructure();

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "fs-extra": "^10.0.0",
     "jscodeshift": "^0.11.0",
     "lodash": "^4.17.21",
-    "lodash-inflection": "^1.5.0",
-    "pluralize": "^8.0.0"
+    "lodash-inflection": "^1.5.0"
   },
   "devDependencies": {
     "jest": "^27.0.6"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "fs-extra": "^10.0.0",
     "jscodeshift": "^0.11.0",
     "lodash": "^4.17.21",
-    "lodash-inflection": "^1.5.0"
+    "lodash-inflection": "^1.5.0",
+    "pluralize": "^8.0.0"
   },
   "devDependencies": {
     "jest": "^27.0.6"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "jscodeshift": "^0.11.0",
     "lodash": "^4.17.21",

--- a/transforms/__testFixtures__/use-arrow-function-for-service-export.input.js
+++ b/transforms/__testFixtures__/use-arrow-function-for-service-export.input.js
@@ -1,0 +1,12 @@
+function foo() {
+  console.log("code");
+}
+
+function bar() {
+  console.log("more code");
+}
+
+module.exports = {
+  foo,
+  bar
+};

--- a/transforms/__testFixtures__/use-arrow-function-for-service-export.output.js
+++ b/transforms/__testFixtures__/use-arrow-function-for-service-export.output.js
@@ -1,0 +1,12 @@
+function foo() {
+  console.log("code");
+}
+
+function bar() {
+  console.log("more code");
+}
+
+module.exports = () => ({
+  foo,
+  bar
+});

--- a/transforms/__tests__/use-arrow-function-for-service-export.test.js
+++ b/transforms/__tests__/use-arrow-function-for-service-export.test.js
@@ -1,0 +1,7 @@
+"use strict";
+
+jest.autoMockOff();
+
+const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+
+defineTest(__dirname, "use-arrow-function-for-service-export");

--- a/transforms/use-arrow-function-for-service-export.js
+++ b/transforms/use-arrow-function-for-service-export.js
@@ -1,4 +1,4 @@
-module.exports = function useNamedExportsForServices(file, api) {
+module.exports = function useArrowFunctionForService(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
 

--- a/transforms/use-arrow-function-for-service-export.js
+++ b/transforms/use-arrow-function-for-service-export.js
@@ -1,4 +1,4 @@
-module.exports = function useNamedExportsForService(file, api) {
+module.exports = function useNamedExportsForServices(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
 

--- a/transforms/use-named-exports-for-service.js
+++ b/transforms/use-named-exports-for-service.js
@@ -1,0 +1,23 @@
+module.exports = function useNamedExportsForService(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const moduleExports = root.find(j.AssignmentExpression, {
+    left: {
+      object: {
+        name: "module",
+      },
+      property: {
+        name: "exports",
+      },
+    },
+  });
+
+  const objectExpression = moduleExports.get().value.right;
+  const arrowFunctionExpression = j.arrowFunctionExpression(
+    [],
+    objectExpression
+  );
+  moduleExports.get().value.right = arrowFunctionExpression;
+  return root.toSource();
+};

--- a/utils/runJsCodeshift.js
+++ b/utils/runJsCodeshift.js
@@ -1,0 +1,21 @@
+const { join } = require("path");
+const jscodeshiftExecutable = require.resolve(".bin/jscodeshift");
+const execa = require("execa");
+
+/**
+ * @description Executes jscodeshift
+ * 
+ * @param {string} path - the path where the transform should run
+ * @param {string} transform - the name of the transform file
+ */
+module.exports = (path, transform) => {
+  const result = execa.sync(jscodeshiftExecutable, [
+    "-t",
+    join(__dirname, "..", "transforms", `${transform}.js`),
+    path,
+  ]);
+
+  if (result.error) {
+    throw result.error;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,7 +1466,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-execa@^5.0.0:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2933,11 +2933,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pluralize@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2933,6 +2933,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
A first PR, but I would like for each function that alters the API to be independent from this script. 

For example, if I just wanted convert models to content-types, maybe I would want these options: 
  1. convert a specific model to content-type
  2. convert all models to content-types for a specific api
  3. convert all models to content-ypes for all apis.